### PR TITLE
lookup: network: return list of strings

### DIFF
--- a/plugins/lookup/network.py
+++ b/plugins/lookup/network.py
@@ -79,7 +79,7 @@ class LookupModule(CapircaLookup):
         for symbol in args:
             try:
                 for net in self._capirca_definitions.GetNet(symbol):
-                    ret.append(net)
+                    ret.append(str(net))
             except naming.UndefinedAddressError:
                 missing = kwargs.get('missing', 'error')
                 if missing == 'warn':


### PR DESCRIPTION
Previously, a list of objects which capirca internally uses was returned. By converting elements to string, we can then use ansible builtin filters e.g. ansible.utils.ipaddr.